### PR TITLE
[feature:gateway-filter and WebClient configuration]

### DIFF
--- a/backend/synthexITBackend/api-gateway/pom.xml
+++ b/backend/synthexITBackend/api-gateway/pom.xml
@@ -33,6 +33,10 @@
             <groupId>io.micrometer</groupId>
             <artifactId>micrometer-registry-prometheus</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-webflux</artifactId>
+        </dependency>
     </dependencies>
 
 </project>

--- a/backend/synthexITBackend/api-gateway/src/main/java/com/devsling/fr/config/AuthWebClientConfig.java
+++ b/backend/synthexITBackend/api-gateway/src/main/java/com/devsling/fr/config/AuthWebClientConfig.java
@@ -1,0 +1,16 @@
+package com.devsling.fr.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.util.Collections;
+@Configuration
+@ConfigurationProperties(prefix = "backend.auth")
+public class AuthWebClientConfig extends WebClientConfiguration{
+    @Bean
+    public WebClient authWebClient(WebClient.Builder webClientBuilder) {
+        return super.webClientBuilder("auth", webClientBuilder, Collections.emptyList()).build();
+    }
+}

--- a/backend/synthexITBackend/api-gateway/src/main/java/com/devsling/fr/config/AuthenticationFilter.java
+++ b/backend/synthexITBackend/api-gateway/src/main/java/com/devsling/fr/config/AuthenticationFilter.java
@@ -1,0 +1,61 @@
+package com.devsling.fr.config;
+
+
+import org.springframework.cloud.gateway.filter.GatewayFilter;
+import org.springframework.cloud.gateway.filter.factory.AbstractGatewayFilterFactory;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Component
+public class AuthenticationFilter extends AbstractGatewayFilterFactory<AuthenticationFilter.Config> {
+
+    private final RouteValidator validator;
+
+    private final WebClient authWebClient;
+
+
+
+    public AuthenticationFilter(RouteValidator validator, WebClient authWebClient) {
+        super(Config.class);
+        this.validator = validator;
+        this.authWebClient = authWebClient;
+    }
+
+    @Override
+    public GatewayFilter apply(Config config) {
+        return ((exchange, chain) -> {
+            if (validator.isSecured.test(exchange.getRequest())) {
+                //header contains token or not
+                if (!exchange.getRequest().getHeaders().containsKey(HttpHeaders.AUTHORIZATION)) {
+                    throw new RuntimeException("missing authorization header");
+                }
+
+                String authHeader = exchange.getRequest().getHeaders().get(HttpHeaders.AUTHORIZATION).get(0);
+                if (authHeader != null && authHeader.startsWith("Bearer ")) {
+                    authHeader = authHeader.substring(7);
+                }
+                try {
+//                    //REST call to AUTH service with WebClient
+                    String finalAuthHeader = authHeader;
+                    authWebClient.get()
+                            .uri(uriBuilder -> uriBuilder
+                                    .path("/auth/validate")
+                                    .queryParam("token", finalAuthHeader)
+                                    .build())
+                            .retrieve();
+
+
+                } catch (Exception e) {
+                    System.out.println("invalid access...!");
+                    throw new RuntimeException("un authorized access to application");
+                }
+            }
+            return chain.filter(exchange);
+        });
+    }
+
+    public static class Config {
+
+    }
+}

--- a/backend/synthexITBackend/api-gateway/src/main/java/com/devsling/fr/config/RouteValidator.java
+++ b/backend/synthexITBackend/api-gateway/src/main/java/com/devsling/fr/config/RouteValidator.java
@@ -1,0 +1,23 @@
+package com.devsling.fr.config;
+
+
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+@Component
+public class RouteValidator {
+    public static final List<String> openApiEndpoints = List.of(
+            "/auth/register",
+            "/auth/token",
+            "/eureka"
+    );
+
+    public Predicate<ServerHttpRequest> isSecured =
+            request -> openApiEndpoints
+                    .stream()
+                    .noneMatch(uri -> request.getURI().getPath().contains(uri));
+
+}

--- a/backend/synthexITBackend/api-gateway/src/main/java/com/devsling/fr/config/WebClientConfiguration.java
+++ b/backend/synthexITBackend/api-gateway/src/main/java/com/devsling/fr/config/WebClientConfiguration.java
@@ -1,0 +1,77 @@
+package com.devsling.fr.config;
+
+import io.netty.channel.ChannelOption;
+import io.netty.handler.logging.LogLevel;
+import io.netty.handler.timeout.ReadTimeoutHandler;
+import io.netty.handler.timeout.WriteTimeoutHandler;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.reactive.ClientHttpConnector;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
+import org.springframework.web.reactive.function.client.ExchangeFilterFunction;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.netty.http.client.HttpClient;
+import reactor.netty.resources.ConnectionProvider;
+import reactor.netty.transport.logging.AdvancedByteBufFormat;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+@Data
+@Builder(toBuilder = true)
+@AllArgsConstructor
+@NoArgsConstructor
+@Slf4j
+public class WebClientConfiguration {
+    @Value("${backend.maxConnections:600}")
+    private int maxConnections;
+    @Value("${backend.acquireTimeout:1000}")
+    private int acquireTimeout;
+    public static final String APPLICATION_JSON_UTF8_VALUE = "application/json;charset=UTF-8";
+
+    private String baseUrl;
+    private int connectTimeout;
+    private int readTimeout;
+    private int writeTimeout;
+    private int responseTimeout;
+
+    protected WebClient.Builder webClientBuilder(String service, WebClient.Builder webClientBuilder,
+                                                 List<? extends ExchangeFilterFunction> requestFilters) {
+
+        WebClient.Builder builder = webClientBuilder
+                .baseUrl(getBaseUrl())
+                .codecs(clientCodecConfigurer -> clientCodecConfigurer.defaultCodecs().maxInMemorySize(-1))
+                .clientConnector(httpClientConnector())
+                .defaultHeader(HttpHeaders.CONTENT_TYPE, APPLICATION_JSON_UTF8_VALUE)
+                .defaultHeader(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE);
+
+        requestFilters.forEach(builder::filter);
+        return builder;
+    }
+
+    protected ClientHttpConnector httpClientConnector() {
+        String connectionProviderName = "fixed";
+        return new ReactorClientHttpConnector(
+                HttpClient.create(
+                                ConnectionProvider.builder(connectionProviderName)
+                                        .maxConnections(maxConnections)
+                                        .pendingAcquireTimeout(Duration.ofMillis(acquireTimeout))
+                                        .build())
+                        .responseTimeout(responseTimeout == 0 ? null : Duration.ofMillis(responseTimeout))
+                        .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, connectTimeout) // millis
+                        .doOnConnected(connection ->
+                                connection
+                                        .addHandlerLast(new ReadTimeoutHandler(readTimeout, TimeUnit.MILLISECONDS))
+                                        .addHandlerLast(new WriteTimeoutHandler(writeTimeout, TimeUnit.MILLISECONDS)))
+                        .wiretap(this.getClass().getCanonicalName(),
+                                LogLevel.DEBUG, AdvancedByteBufFormat.TEXTUAL)
+        );
+    }
+}

--- a/backend/synthexITBackend/api-gateway/src/main/resources/application.yml
+++ b/backend/synthexITBackend/api-gateway/src/main/resources/application.yml
@@ -13,11 +13,15 @@ spring:
           uri: lb://CANDIDATE-SERVICE
           predicates:
             - Path=/candidate/**
+          filters:
+            - AuthenticationFilter
 
         - id: employer-service
           uri: lb://EMPLOYER-SERVICE
           predicates:
             - Path=/employer/**
+          filters:
+            - AuthenticationFilter
 
   application:
     name: api-gateway
@@ -40,3 +44,12 @@ management:
       web:
         exposure:
           include: prometheus
+backend:
+  maxConnections: 600
+  acquireTimeout: 1000
+  auth:
+    baseUrl: https://localhost:8083
+    connectTimeout: 3000
+    readTimeout: 3000
+    writeTimeout: 3000
+    responseTimeout: 3000

--- a/backend/synthexITBackend/authentication-service/src/main/java/com/devsling/fr/controller/AdminController.java
+++ b/backend/synthexITBackend/authentication-service/src/main/java/com/devsling/fr/controller/AdminController.java
@@ -1,4 +1,16 @@
 package com.devsling.fr.controller;
 
+import com.devsling.fr.service.UserService;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/admin")
 public class AdminController {
+
+    private final UserService userService;
+
+    public AdminController(UserService userService) {
+        this.userService = userService;
+    }
 }

--- a/backend/synthexITBackend/authentication-service/src/main/java/com/devsling/fr/security/SecurityConfig.java
+++ b/backend/synthexITBackend/authentication-service/src/main/java/com/devsling/fr/security/SecurityConfig.java
@@ -25,6 +25,7 @@ public class SecurityConfig {
                         .requestMatchers("/auth/register").permitAll()
                         .requestMatchers("/auth/token").permitAll()
                         .requestMatchers("/auth/validate").permitAll()
+                        .requestMatchers("/swagger-ui.html").permitAll()
                         .anyRequest().authenticated()
                 )
                 .sessionManagement(sess -> sess.sessionCreationPolicy(SessionCreationPolicy.STATELESS))


### PR DESCRIPTION
Description:

Implement OpenAPI endpoints for /eureka, /auth/register, and /auth/token, allowing access without requiring a token in the header.
Introduce a RouteValidator in the gateway to manage open API endpoints without token requirements.
Implement an AuthenticationFilter in the gateway to enforce token presence in the Authorization header for all other requests.
Ensure that each request with a JWT token triggers a call to the /auth/validate endpoint in the auth service for token validation.
Configure global WebClient settings in the gateway for asynchronous, non-blocking calls to the auth-service backend.
Make all requests to the gateway with a JWT token, requiring validation through the /auth/validate endpoint in the auth service.