### PR TITLE
 Candidate Resume Management

### DIFF
--- a/backend/synthexITBackend/candidate-service/pom.xml
+++ b/backend/synthexITBackend/candidate-service/pom.xml
@@ -132,6 +132,10 @@
                <version>0.11.5</version>
                <scope>compile</scope>
            </dependency>
+           <dependency>
+               <groupId>org.apache.commons</groupId>
+               <artifactId>commons-lang3</artifactId>
+           </dependency>
        </dependencies>
 
     <build>

--- a/backend/synthexITBackend/candidate-service/src/main/java/com/devsling/fr/dto/FileUploadResponse.java
+++ b/backend/synthexITBackend/candidate-service/src/main/java/com/devsling/fr/dto/FileUploadResponse.java
@@ -1,0 +1,20 @@
+package com.devsling.fr.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder(toBuilder = true)
+@AllArgsConstructor
+@NoArgsConstructor
+public class FileUploadResponse {
+    @JsonProperty("fileName")
+    private String fileName;
+    @JsonProperty("downloadUri")
+    private String downloadUri;
+    @JsonProperty("size")
+    private long size;
+}

--- a/backend/synthexITBackend/candidate-service/src/main/java/com/devsling/fr/model/Candidate.java
+++ b/backend/synthexITBackend/candidate-service/src/main/java/com/devsling/fr/model/Candidate.java
@@ -55,4 +55,5 @@ public class Candidate implements Serializable {
     @OneToOne
     @JoinColumn(name = "image_data_id", referencedColumnName = "id")
     private String imageName;
+
 }

--- a/backend/synthexITBackend/candidate-service/src/main/java/com/devsling/fr/service/CandidateService.java
+++ b/backend/synthexITBackend/candidate-service/src/main/java/com/devsling/fr/service/CandidateService.java
@@ -2,6 +2,7 @@ package com.devsling.fr.service;
 
 import com.devsling.fr.dto.CandidateDto;
 import com.devsling.fr.dto.CandidateProfileResponse;
+import com.devsling.fr.dto.FileUploadResponse;
 import com.devsling.fr.dto.ImageResponse;
 import com.devsling.fr.dto.UploadImageResponse;
 import org.springframework.web.multipart.MultipartFile;
@@ -21,4 +22,6 @@ public interface CandidateService {
     Mono<UploadImageResponse> uploadCandidateImage(MultipartFile file,Long candidateId) throws IOException;
 
     Mono<ImageResponse>  getProfileImage(String fileName);
+    Mono<FileUploadResponse> uploadCandidateCv(MultipartFile file, Long candidateId) throws IOException;
+
 }

--- a/backend/synthexITBackend/candidate-service/src/main/java/com/devsling/fr/service/FileStorageService.java
+++ b/backend/synthexITBackend/candidate-service/src/main/java/com/devsling/fr/service/FileStorageService.java
@@ -2,11 +2,15 @@ package com.devsling.fr.service;
 
 import java.io.IOException;
 
+import com.devsling.fr.dto.FileUploadResponse;
 import com.devsling.fr.dto.UploadImageResponse;
+import org.springframework.core.io.Resource;
 import org.springframework.web.multipart.MultipartFile;
 import reactor.core.publisher.Mono;
 
 public interface  FileStorageService {
     Mono<UploadImageResponse> uploadImage(MultipartFile file) throws IOException;
     Mono<byte[]> downloadImage(String fileName);
+     Mono<FileUploadResponse> uploadFile(MultipartFile file) throws IOException;
+    Mono<Resource> downloadFile(String fileCode);
 }

--- a/backend/synthexITBackend/candidate-service/src/main/java/com/devsling/fr/tools/FileUploadUtils.java
+++ b/backend/synthexITBackend/candidate-service/src/main/java/com/devsling/fr/tools/FileUploadUtils.java
@@ -1,0 +1,78 @@
+package com.devsling.fr.tools;
+
+import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang.RandomStringUtils;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.io.InputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.UrlResource;
+
+@Component
+public class FileUploadUtils {
+
+    private   Path foundFile;
+
+    public  String saveFile(String fileName, MultipartFile multipartFile)
+            throws IOException {
+        Path uploadPath = Paths.get("Files-Upload");
+
+        if (!Files.exists(uploadPath)) {
+            Files.createDirectories(uploadPath);
+        }
+
+        String fileCode = RandomStringUtils.randomAlphanumeric(8);
+
+        try (InputStream inputStream = multipartFile.getInputStream()) {
+            Path filePath = uploadPath.resolve(fileCode + "-" + fileName);
+            Files.copy(inputStream, filePath, StandardCopyOption.REPLACE_EXISTING);
+        } catch (IOException ioe) {
+            throw new IOException("Could not save file: " + fileName, ioe);
+        }
+
+        return fileCode;
+    }
+
+    public Resource getFileAsResource(String fileCode) throws IOException {
+        Path dirPath = Paths.get("Files-Upload");
+
+        Files.list(dirPath).forEach(file -> {
+            if (file.getFileName().toString().startsWith(fileCode)) {
+                foundFile = file;
+                return;
+            }
+        });
+
+        if (foundFile != null) {
+            return new UrlResource(foundFile.toUri());
+        }
+
+        return null;
+    }
+
+    //verify the delete file when we update the existing file not deleted
+    public void deleteFile(String fileCode) throws IOException {
+        Path dirPath = Paths.get("Files-Upload");
+
+        Files.list(dirPath).forEach(file -> {
+            if (file.getFileName().toString().startsWith(fileCode)) {
+                try {
+                    Files.deleteIfExists(file);
+                } catch (IOException e) {
+                    throw new RuntimeException("Failed to delete file: " + file.toString(), e);
+                }
+            }
+        });
+    }
+}


### PR DESCRIPTION
The Candidate Resume Management feature enables users to upload, download, and delete resumes for candidates in the system. This feature facilitates efficient management of candidate documents and provides easy access to their resumes as needed. Below are the key functionalities of this feature:

Upload Candidate Resume:

Users can upload resumes for candidates through a user-friendly interface.
The system generates a unique identifier for each uploaded resume file, ensuring secure storage and easy retrieval.
Resumes are stored on disk, and the system associates them with the corresponding candidate records in the database.
Download Candidate Resume:

Authorized users can download resumes of candidates from the system.
Resumes are retrieved based on the unique identifier assigned during the upload process.
Downloaded resumes are provided as downloadable files, enabling users to view or save them locally.
Delete Candidate Resume:

Users with appropriate permissions can delete resumes of candidates when necessary.
Deletion of resumes removes the associated files from disk storage and updates the candidate records accordingly.
This feature helps maintain data integrity by allowing the removal of outdated or irrelevant resumes from the system.